### PR TITLE
Motif multithread fasta input

### DIFF
--- a/liquidator/detail/score_matrix_detail.h
+++ b/liquidator/detail/score_matrix_detail.h
@@ -79,10 +79,10 @@ scale(const PWM& pwm, const std::pair<double, double>& min_max, const unsigned r
 }
 
 // returns score; sequences with invalid characters return 0.
-unsigned score(const std::vector<std::array<unsigned, AlphabetSize>>& matrix,
-               const std::string& sequence,
-               const size_t begin,
-               const size_t end)
+inline unsigned score(const std::vector<std::array<unsigned, AlphabetSize>>& matrix,
+                      const std::string& sequence,
+                      const size_t begin,
+                      const size_t end)
 {
     assert(end >= begin);
     assert((end-begin) <= matrix.size());
@@ -106,7 +106,7 @@ unsigned score(const std::vector<std::array<unsigned, AlphabetSize>>& matrix,
     return score;
 }
 
-unsigned max(const std::vector<std::array<unsigned, AlphabetSize>>& matrix)
+inline unsigned max(const std::vector<std::array<unsigned, AlphabetSize>>& matrix)
 {
     unsigned max = 0;
     for (const auto& row : matrix)
@@ -121,7 +121,7 @@ unsigned max(const std::vector<std::array<unsigned, AlphabetSize>>& matrix)
 
 // returns probability distribution values (based on background) indexed by
 // all possible integer scores (with the max_score = matrix_max_value * number_of_rows)
-std::vector<double>
+inline std::vector<double>
 probability_distribution(const std::vector<std::array<unsigned, AlphabetSize>>& matrix,
                          const std::array<double, AlphabetSize>& background)
 {
@@ -163,7 +163,7 @@ probability_distribution(const std::vector<std::array<unsigned, AlphabetSize>>& 
     return current;
 }
 
-void pdf_to_pvalues(std::vector<double>& p)
+inline void pdf_to_pvalues(std::vector<double>& p)
 {
     if (p.size() <= 1) return;
 
@@ -177,7 +177,7 @@ void pdf_to_pvalues(std::vector<double>& p)
     }
 }
 
-void reverse_complement(std::vector<std::array<double, AlphabetSize>>& matrix)
+inline void reverse_complement(std::vector<std::array<double, AlphabetSize>>& matrix)
 {
     std::reverse(matrix.begin(), matrix.end());
     for (auto& row: matrix)
@@ -186,7 +186,7 @@ void reverse_complement(std::vector<std::array<double, AlphabetSize>>& matrix)
     }
 }
 
-std::array<double, AlphabetSize> adjust_background(std::array<double, AlphabetSize> background, bool average_for_reverse)
+inline std::array<double, AlphabetSize> adjust_background(std::array<double, AlphabetSize> background, bool average_for_reverse)
 {
     if (average_for_reverse)
     {

--- a/liquidator/fasta_scorer.cpp
+++ b/liquidator/fasta_scorer.cpp
@@ -1,0 +1,37 @@
+#include "fasta_scorer.h"
+
+#include "fasta_reader.h"
+#include "fimo_style_printer.h"
+
+#include <fstream>
+
+namespace liquidator
+{
+
+void process_fasta(const std::vector<ScoreMatrix>& matrices,
+                   const std::string& fasta_file_path,
+                   const std::string& output_file_path)
+{
+    std::ifstream fasta_input(fasta_file_path);
+    if (!fasta_input)
+    {
+        throw std::runtime_error("failed to open " + fasta_file_path);
+    }
+
+    std::ofstream output(output_file_path);
+    FimoStylePrinter printer(output);
+
+    FastaReader fasta_reader(fasta_input);
+    std::string sequence;
+    std::string sequence_name;
+    while (fasta_reader.next_read(sequence, sequence_name))
+    {
+        for (const auto& matrix : matrices)
+        {
+            printer.sequence_name = &sequence_name;
+            matrix.score(sequence, printer);
+        }
+    }
+}
+
+}

--- a/liquidator/fasta_scorer.cpp
+++ b/liquidator/fasta_scorer.cpp
@@ -2,15 +2,28 @@
 
 #include "fasta_reader.h"
 #include "fimo_style_printer.h"
+#include "detail/score_matrix_detail.h"
 
+#include <tbb/blocked_range.h>
+#include <tbb/enumerable_thread_specific.h>
+#include <tbb/parallel_for.h>
+#include <tbb/task_scheduler_init.h>
+
+#include <boost/timer/timer.hpp>
+
+#include <cerrno>
 #include <fstream>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <sstream>
 
 namespace liquidator
 {
 
-void process_fasta(const std::vector<ScoreMatrix>& matrices,
-                   const std::string& fasta_file_path,
-                   const std::string& output_file_path)
+void process_fasta_serial(const std::vector<ScoreMatrix>& matrices,
+                          const std::string& fasta_file_path,
+                          const std::string& output_file_path)
 {
     std::ifstream fasta_input(fasta_file_path);
     if (!fasta_input)
@@ -34,4 +47,246 @@ void process_fasta(const std::vector<ScoreMatrix>& matrices,
     }
 }
 
+std::string get_file_contents(const std::string& file_path)
+{
+    // Seems to be fastest way to read entire file into memory, based off of
+    // http://insanecoding.blogspot.com/2011/11/how-to-read-in-file-in-c.html
+
+    std::ifstream in(file_path, std::ios::in | std::ios::binary);
+    if (!in)
+    {
+        std::stringstream ss;
+        ss << "Failed to open file " << file_path << ": error " << errno;
+        throw std::runtime_error(ss.str());
+    }
+    std::string contents;
+    in.seekg(0, std::ios::end);
+    contents.resize(in.tellg());
+    in.seekg(0, std::ios::beg);
+    in.read(&contents[0], contents.size());
+    in.close();
+    return contents;
 }
+
+struct FimoStyleOutputInfo
+{
+    size_t fasta_sequence_name_begin;
+    size_t fasta_sequence_name_length; // todo: try uint8_t
+
+    double score; // todo: try changing to floats
+    double pvalue;
+
+    const std::string& motif_name;
+
+    // FASTA spec suggests sequences must be <= 80 long, so 256 should be plenty.
+    // Assuming this small size for now for best case performance timings.
+    uint8_t sequence_start; // named start instead of begin because this is already 1 indexed for output
+    uint8_t sequence_stop;
+
+    char strand;
+};
+
+class Scorer
+{
+public:
+    Scorer(const std::vector<ScoreMatrix>& matrices,
+           const std::string& fasta,
+           std::ofstream& output,
+           std::mutex& output_mutex)
+    :
+        matrices(matrices),
+        fasta(fasta),
+        output(output),
+        output_mutex(output_mutex)
+    {}
+
+    Scorer(const Scorer& other)
+    :
+        matrices(other.matrices),
+        fasta(other.fasta),
+        output(other.output),
+        output_mutex(other.output_mutex)
+    {}
+
+    ~Scorer()
+    {
+        std::lock_guard<std::mutex> lock(output_mutex);
+
+        for (const auto& info: infos)
+        {
+            output << info.motif_name << '\t';
+            output.write(fasta.data() + info.fasta_sequence_name_begin, info.fasta_sequence_name_length);
+            output << '\t'
+                   << static_cast<unsigned>(info.sequence_start) << '\t'
+                   << static_cast<unsigned>(info.sequence_stop) << '\t'
+                   << info.strand << '\t';
+
+            output.precision(6);
+            output << info.score << '\t';
+            output.precision(3);
+
+            output << info.pvalue << '\t'
+                   << '\t'; // omit q-value for now
+
+            // todo: should really do toupper
+            // sequence_begin +1 for new line between name end and sequence, -1 for start being 1 based (so cancels out)
+            const size_t sequence_begin = info.fasta_sequence_name_begin + info.fasta_sequence_name_length + info.sequence_start;
+
+            // sequence_length +1 because start is 1 based
+            const size_t sequence_length = info.sequence_stop - info.sequence_start + 1;
+            if (info.strand == '+')
+            {
+                output.write(fasta.data() + sequence_begin,
+                             sequence_length);
+            }
+            else
+            {
+                for (size_t i=sequence_begin + sequence_length - 1; ; --i)
+                {
+                    output << complement(fasta[i]);
+                    if (i==sequence_begin)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            output << std::endl;
+        }
+    }
+
+    Scorer& operator=(const Scorer& other) = delete;
+
+    void score(size_t region_begin, const size_t region_end)
+    {
+        while(true)
+        {
+            // todo: is > a valid char in a sequence name? maybe we should search for "\n>" char* instead of single char
+            size_t name_begin = fasta.find_first_of('>', region_begin);
+            if (name_begin >= region_end)
+            {
+                break;
+            }
+            name_begin++; // name starts character after '>'
+            size_t name_end = fasta.find_first_of('\n', name_begin+1);
+
+            size_t sequence_begin = name_end + 1;
+            // this assumes the file is terminated by a newline, otherwise last sequence won't have an end
+            size_t sequence_end = fasta.find_first_of('\n', sequence_begin + 1);
+
+            for (const auto& matrix : matrices)
+            {
+                for (size_t begin = sequence_begin, end = sequence_begin + matrix.matrix().size();
+                     end <= sequence_end;
+                     ++begin, ++end)
+                {
+                    // todo: experiment with switching loop order: move matrix loop inside sequence loop
+                    const unsigned scaled_score = detail::score(matrix.matrix(),
+                                                                fasta,
+                                                                begin,
+                                                                end);
+                    const auto& pvalues = matrix.pvalues();
+                    assert(scaled_score < pvalues.size());
+                    const double pvalue = pvalues[scaled_score];
+                    if (pvalue < 0.0001)
+                    {
+                        const double unscaled_score = double(scaled_score)/matrix.scale()
+                            + matrix.matrix().size()*matrix.min_before_scaling();
+                        infos.push_back({name_begin,
+                                         name_end-name_begin,
+                                         unscaled_score,
+                                         pvalue,
+                                         matrix.name(),
+                                         // todo: do a cast or something to silence narrowing warning
+                                         begin - sequence_begin + 1,
+                                         end - sequence_begin,
+                                         matrix.is_reverse_complement() ? '-' : '+'});
+                    }
+                }
+            }
+
+            region_begin = sequence_end + 1;
+        }
+    }
+
+private:
+    const std::vector<ScoreMatrix>& matrices;
+    const std::string& fasta;
+
+    std::ofstream& output;
+    std::mutex& output_mutex;
+
+    std::vector<FimoStyleOutputInfo> infos;
+};
+
+typedef tbb::enumerable_thread_specific<Scorer,
+                                        tbb::cache_aligned_allocator<Scorer>,
+                                        tbb::ets_key_per_instance>
+        Scorers;
+
+void score_fasta(size_t region_begin, size_t region_end, Scorers& scorers)
+{
+    Scorer& scorer = scorers.local();
+    scorer.score(region_begin, region_end);
+}
+
+void process_fasta(const std::vector<ScoreMatrix>& matrices,
+                   const std::string& fasta_file_path,
+                   const std::string& output_file_path)
+{
+    tbb::task_scheduler_init init(tbb::task_scheduler_init::automatic);
+
+    boost::timer::cpu_timer timer;
+    const std::string fasta = get_file_contents(fasta_file_path);
+    timer.stop();
+    //std::cout << "reading " << fasta.size() << " bytes fasta file into memory took" << timer.format() << std::endl;
+    // todo: instead of reading entire file into memory, just figure out how many char,
+    //       then try having the scorers read the chunks into memory themselves.
+    //       or maybe try the pipeline suggested in tbb documentation:
+    //       https://www.threadingbuildingblocks.org/docs/help/tbb_userguide/Working_on_the_Assembly_Line_pipeline.html
+    //       this is currently nice in its simplicity though.
+
+    std::ofstream output(output_file_path);
+    output << "#pattern name\tsequence name\tstart\tstop\tstrand\tscore\tp-value\tq-value\tmatched sequence" << std::endl;
+    std::mutex output_mutex;
+
+    Scorers scorers((Scorer(matrices, fasta, output, output_mutex)));
+
+    // todo: follow instructions to pick proper grain size:
+    // https://www.threadingbuildingblocks.org/docs/doxygen/a00023.html#a49a97576004711b7159170fcaf488e4e
+    // actually, that documentation might be outdated... maybe grainsize of 1 fine because of auto_partitioner
+    const size_t grainsize = 8400; // size of 100 fasta entries from a sample file
+
+    tbb::parallel_for(
+      tbb::blocked_range<int>(0, fasta.size(), grainsize),
+      [&](const tbb::blocked_range<int>& range)
+      {
+        score_fasta(range.begin(), range.end(), scorers);
+      },
+      tbb::auto_partitioner());
+}
+
+}
+
+/* The MIT License (MIT)
+
+   Copyright (c) 2016 Boulder Labs (jdimatteo@boulderlabs.com)
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */

--- a/liquidator/fasta_scorer.h
+++ b/liquidator/fasta_scorer.h
@@ -1,0 +1,18 @@
+#ifndef LIQUIDATOR_FASTA_SCORER_H_INCLUDED
+#define LIQUIDATOR_FASTA_SCORER_H_INCLUDED
+
+#include "score_matrix.h"
+
+#include <string>
+#include <vector>
+
+namespace liquidator
+{
+
+void process_fasta(const std::vector<ScoreMatrix>& matrices,
+                   const std::string& fasta_file_path,
+                   const std::string& output_file_path);
+
+}
+
+#endif

--- a/liquidator/fasta_scorer.h
+++ b/liquidator/fasta_scorer.h
@@ -16,3 +16,26 @@ void process_fasta(const std::vector<ScoreMatrix>& matrices,
 }
 
 #endif
+
+/* The MIT License (MIT)
+
+   Copyright (c) 2016 Boulder Labs (jdimatteo@boulderlabs.com)
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */

--- a/liquidator/makefile
+++ b/liquidator/makefile
@@ -39,7 +39,7 @@ CC=g++
 # CPPFLAGS used to include march=native, but was removed so executables would 
 # work on platforms besides the one used for the build
 OPTIMIZATION_LEVEL := -O3 -DNDEBUG # normally -O3 with asserts disabled for performance
-#OPTIMIZATION_LEVEL := -O0 # -O0 and asserts enabled for easier debugging
+OPTIMIZATION_LEVEL := -O0 # -O0 and asserts enabled for easier debugging
 CPPFLAGS := -std=c++11 $(OPTIMIZATION_LEVEL) -g -Wall -I ./
 LDFLAGS := $(OPTIMIZATION_LEVEL) -g -Wall
 LDLIBS := -lbam -lz -lpthread -ltbb
@@ -94,7 +94,7 @@ bamliquidator_regions: bamliquidator_regions.m.o bamliquidator.o liquidator_util
 	$(CC) $(LDFLAGS) -o bamliquidator_regions bamliquidator.o bamliquidator_regions.m.o liquidator_util.o \
 					$(LDLIBS) $(ADDITIONAL_LDLIBS) 
 
-score_matrix.o: score_matrix.h score_matrix.cpp detail/score_matrix_detail.h fimo_style_printer.h
+score_matrix.o: score_matrix.h score_matrix.cpp detail/score_matrix_detail.h
 	$(CC) $(CPPFLAGS) -c score_matrix.cpp 
 
 define VERSION_H
@@ -120,8 +120,8 @@ version.h: bamliquidatorbatch/common_util.py
 	echo "$$VERSION_H" > version.h
 
 # todo: add to dev checklist: sudo apt-get install libboost-program-options1.54-dev libboost-filesystem1.54-dev
-motif_liquidator: motif_liquidator.m.cpp score_matrix.o parsing_detail.o fasta_reader.h bam_scorer.h liquidator_util.o version.h
-	$(CC) $(CPPFLAGS) motif_liquidator.m.cpp $(LDFLAGS) -o motif_liquidator score_matrix.o liquidator_util.o parsing_detail.o $(LDLIBS) -lboost_program_options -lboost_filesystem -lboost_system
+motif_liquidator: motif_liquidator.m.cpp score_matrix.o parsing_detail.o bam_scorer.h liquidator_util.o version.h fasta_scorer.o
+	$(CC) $(CPPFLAGS) motif_liquidator.m.cpp $(LDFLAGS) -o motif_liquidator score_matrix.o liquidator_util.o parsing_detail.o fasta_scorer.o $(LDLIBS) -lboost_program_options -lboost_filesystem -lboost_system
 
 bamliquidator.m.o: bamliquidator.m.cpp
 	$(CC) $(CPPFLAGS) -c bamliquidator.m.cpp
@@ -138,8 +138,11 @@ bamliquidator.o: bamliquidator.cpp bamliquidator.h
 liquidator_util.o: liquidator_util.cpp liquidator_util.h
 	$(CC) $(CPPFLAGS) -c liquidator_util.cpp
 
-parsing_detail.o: detail/parsing_detail.cpp liquidator_util.h detail/pwm_detail.h
+parsing_detail.o: detail/parsing_detail.h detail/parsing_detail.cpp liquidator_util.h detail/pwm_detail.h
 	$(CC) $(CPPFLAGS) -c detail/parsing_detail.cpp
+
+fasta_scorer.o: fasta_scorer.cpp fasta_scorer.h score_matrix.o fimo_style_printer.h fasta_reader.h
+	$(CC) $(CPPFLAGS) -c fasta_scorer.cpp
 
 EXECUTABLES = bamliquidator bamliquidator_bins bamliquidator_regions motif_liquidator
 

--- a/liquidator/makefile
+++ b/liquidator/makefile
@@ -39,7 +39,7 @@ CC=g++
 # CPPFLAGS used to include march=native, but was removed so executables would 
 # work on platforms besides the one used for the build
 OPTIMIZATION_LEVEL := -O3 -DNDEBUG # normally -O3 with asserts disabled for performance
-OPTIMIZATION_LEVEL := -O0 # -O0 and asserts enabled for easier debugging
+#OPTIMIZATION_LEVEL := -O0 # -O0 and asserts enabled for easier debugging
 CPPFLAGS := -std=c++11 $(OPTIMIZATION_LEVEL) -g -Wall -I ./
 LDFLAGS := $(OPTIMIZATION_LEVEL) -g -Wall
 LDLIBS := -lbam -lz -lpthread -ltbb
@@ -121,7 +121,7 @@ version.h: bamliquidatorbatch/common_util.py
 
 # todo: add to dev checklist: sudo apt-get install libboost-program-options1.54-dev libboost-filesystem1.54-dev
 motif_liquidator: motif_liquidator.m.cpp score_matrix.o parsing_detail.o bam_scorer.h liquidator_util.o version.h fasta_scorer.o
-	$(CC) $(CPPFLAGS) motif_liquidator.m.cpp $(LDFLAGS) -o motif_liquidator score_matrix.o liquidator_util.o parsing_detail.o fasta_scorer.o $(LDLIBS) -lboost_program_options -lboost_filesystem -lboost_system
+	$(CC) $(CPPFLAGS) motif_liquidator.m.cpp $(LDFLAGS) -o motif_liquidator score_matrix.o liquidator_util.o parsing_detail.o fasta_scorer.o $(LDLIBS) -lboost_program_options -lboost_filesystem -lboost_system -lboost_timer
 
 bamliquidator.m.o: bamliquidator.m.cpp
 	$(CC) $(CPPFLAGS) -c bamliquidator.m.cpp
@@ -176,7 +176,7 @@ gtest:
 cpp_test: gtest test.cpp score_matrix.o parsing_detail.o
 	$(CC) $(CPPFLAGS) -o cpp_test parsing_detail.o -I gtest/include test.cpp gtest/build/libgtest.a -pthread 
 
-test: cpp_test 
+test: cpp_test all
 	./cpp_test
 	python bamliquidatorbatch/test.py
 

--- a/liquidator/makefile
+++ b/liquidator/makefile
@@ -36,8 +36,9 @@ bindir = $(prefix)/bin
 #CC=clang++
 CC=g++
 
-# CPPFLAGS used to include march=native, but was removed so executables would 
-# work on platforms besides the one used for the build
+# CPPFLAGS used to include -march=native, but was removed so executables would 
+# work on platforms besides the one used for the build. Performance difference 
+# seems negligible.
 OPTIMIZATION_LEVEL := -O3 -DNDEBUG # normally -O3 with asserts disabled for performance
 #OPTIMIZATION_LEVEL := -O0 # -O0 and asserts enabled for easier debugging
 CPPFLAGS := -std=c++11 $(OPTIMIZATION_LEVEL) -g -Wall -I ./

--- a/liquidator/motif_liquidator.m.cpp
+++ b/liquidator/motif_liquidator.m.cpp
@@ -1,6 +1,5 @@
 #include "bam_scorer.h"
-#include "fasta_reader.h"
-#include "fimo_style_printer.h"
+#include "fasta_scorer.h"
 #include "score_matrix.h"
 #include "version.h"
 
@@ -158,30 +157,6 @@ int process_command_line(int argc,
     }
 
     return 0;
-}
-
-void process_fasta(const std::vector<ScoreMatrix>& matrices, const std::string& fasta_file_path, const std::string& output_file_path)
-{
-    std::ifstream fasta_input(fasta_file_path);
-    if (!fasta_input)
-    {
-        throw std::runtime_error("failed to open " + fasta_file_path);
-    }
-
-    std::ofstream output(output_file_path);
-    FimoStylePrinter printer(output);
-
-    FastaReader fasta_reader(fasta_input);
-    std::string sequence;
-    std::string sequence_name;
-    while (fasta_reader.next_read(sequence, sequence_name))
-    {
-        for (const auto& matrix : matrices)
-        {
-            printer.sequence_name = &sequence_name;
-            matrix.score(sequence, printer);
-        }
-    }
 }
 
 int main(int argc, char** argv)

--- a/liquidator/score_matrix.h
+++ b/liquidator/score_matrix.h
@@ -93,6 +93,36 @@ public:
         return m_matrix[position][column];
     }
 
+    const std::string& name() const
+    {
+        return m_name;
+    }
+
+    bool is_reverse_complement() const
+    {
+        return m_is_reverse_complement;
+    }
+
+    const std::vector<std::array<unsigned, AlphabetSize>>& matrix() const
+    {
+        return m_matrix;
+    }
+
+    double scale() const
+    {
+        return m_scale;
+    }
+
+    double min_before_scaling() const
+    {
+        return m_min_before_scaling;
+    }
+
+    const std::vector<double>& pvalues() const
+    {
+        return m_pvalues;
+    }
+
 private:
     const std::string m_name;
     const bool m_is_reverse_complement;


### PR DESCRIPTION
Still need some refinement before merging, but I think this may be good enough fasta performance for now.

This is about 4.32x faster than the prior single threaded execution on a 4 core machine. (with hyper-threading so 8 virtual cores total).  So if the prior version was 8.3x faster than fimo, this should be 35.8x faster than fimo now.  Brings execution of a test case fasta input for chromosome 1 from ~50 seconds for fimo to 1.94 seconds now.  We need to start testing with multiple motifs or something to get longer runtimes to justify further performance improvements.

After about 4 scoring threads, performance doesn't improve much I think because the (sequential) writing of the output starts to dominate.  Even if scoring was instantaneous, we would still be at about 0.588079 seconds (~85x faster than fimo) because of the sequential file reading/writing -- again we need fasta test cases with longer execution before we start worrying about this.  Here are some performance timings/charts:

https://docs.google.com/a/boulderlabs.com/spreadsheets/d/1H9ZY6HLPY1qKIiIbbld9Pz05N0eFyY1nsoK42XWtR4g/edit?usp=sharing
